### PR TITLE
Update to use Node 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ outputs:
   cardContent:
     description: 'Parsed post metadata'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'


### PR DESCRIPTION
Given that this uses optional chaining, we should not be using Node 12.