### PR TITLE
Adjust heading to reflect Issue Form syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ async function getIssue() {
 
 async function doStuff() {
     const issue = await getIssue();
-    const sections = issue.body.split('##');
+    const sections = issue.body.split('###');
     const content = {};
     for(const section of sections) {
         const [ title, ...body ] = section.split('\n');


### PR DESCRIPTION
Issue Forms use `###` as headings, so the easiest way to handle this is to adjust this on our side. I didn't find a way to configure this.